### PR TITLE
Remove duplicate Microsoft.ReactNative.vcxproj causing build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fs",
-  "version": "2.16.8",
+  "version": "2.16.9",
   "description": "Native filesystem access for react-native",
   "main": "FS.common.js",
   "typings": "index.d.ts",

--- a/windows/RNFS-vnext/RNFSvnext.csproj
+++ b/windows/RNFS-vnext/RNFSvnext.csproj
@@ -144,10 +144,6 @@
       <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
       <Name>Microsoft.ReactNative</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\node_modules\react-native-windows\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj">
-      <Project>{f7d32bd0-2749-483e-9a0d-1635ef7e3136}</Project>
-      <Name>Microsoft.ReactNative</Name>
-    </ProjectReference>
   </ItemGroup>
   <ImportGroup Label="Shared">
     <Import Project="..\..\..\react-native-windows\Microsoft.ReactNative.SharedManaged\Microsoft.ReactNative.SharedManaged.projitems" Label="Shared" Condition="Exists('..\..\..\react-native-windows\Microsoft.ReactNative.SharedManaged\Microsoft.ReactNative.SharedManaged.projitems')" />


### PR DESCRIPTION
This duplicate appears to be causing build failures in the main project