### PR TITLE
fix(electron): wait for write stream to close in downloadFile

### DIFF
--- a/src/__tests__/electron-main.test.ts
+++ b/src/__tests__/electron-main.test.ts
@@ -263,6 +263,81 @@ describe("electron/main filesystem API", () => {
     });
   });
 
+  describe("downloadFile", () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    function mockFetchWithChunks(chunks: Uint8Array[]) {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(chunk);
+          }
+          controller.close();
+        }
+      });
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body
+      }) as unknown as typeof fetch;
+    }
+
+    it("file is fully readable immediately after resolving", async () => {
+      // Contract: when downloadFile resolves, the file is fully flushed
+      // and the fd is closed. (In production the bug surfaced over IPC,
+      // where the renderer's follow-up readFile raced the main process's
+      // pending stream flush; this test exercises the happy path.)
+      const expected = Buffer.alloc(1024 * 64, "x");
+      const mid = expected.length / 2;
+      mockFetchWithChunks([
+        new Uint8Array(expected.subarray(0, mid)),
+        new Uint8Array(expected.subarray(mid))
+      ]);
+
+      const toFile = path.join(tmpDir, "download-flush.bin");
+      const result = await filesystem.api.downloadFile(event, {
+        jobId: 1,
+        fromUrl: "https://example.test/file.bin",
+        toFile,
+        headers: {},
+        background: false,
+        progressDivider: 0,
+        readTimeout: 0,
+        connectionTimeout: 0
+      });
+
+      expect(result.bytesWritten).toBe(expected.length);
+      const onDisk = await fs.readFile(toFile);
+      expect(Buffer.compare(onDisk, expected)).toBe(0);
+    });
+
+    it("propagates fetch errors", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        body: null
+      }) as unknown as typeof fetch;
+
+      await expect(
+        filesystem.api.downloadFile(event, {
+          jobId: 2,
+          fromUrl: "https://example.test/missing",
+          toFile: path.join(tmpDir, "missing.bin"),
+          headers: {},
+          background: false,
+          progressDivider: 0,
+          readTimeout: 0,
+          connectionTimeout: 0
+        })
+      ).rejects.toThrow(/Failed to download file/);
+    });
+  });
+
   describe("main.init", () => {
     it("registers IPC handlers for all API methods", () => {
       const { ipcMain } = require("electron");

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -195,13 +195,22 @@ async function downloadFile(
 
   const reader = body.getReader();
   const fd = await fs.open(options.toFile, "w");
+  // fd.createWriteStream() defaults to autoClose: true, so the stream
+  // takes ownership of the fd and closes it on "close" / on destroy().
   const writer = fd.createWriteStream();
 
   const bytesDone = await _streamFile(reader, writer);
 
-  writer.end();
-
-  await fd.close();
+  // writer.end() only *signals* end-of-stream; pending chunks are still
+  // being flushed to the OS, and the fd has not yet been closed. If we
+  // resolve here, a renderer that immediately calls readFile() over IPC
+  // can race and observe an empty or partial file. Wait for "close" so
+  // the bytes are flushed and the fd is released before we reply.
+  await new Promise<void>((resolve, reject) => {
+    writer.once("close", () => resolve());
+    writer.once("error", reject);
+    writer.end();
+  });
 
   return {
     jobId: options.jobId,


### PR DESCRIPTION
## Summary

- Wait for the WriteStream's `"close"` event in `downloadFile` (electron main) before resolving, so callers see a fully-written file.
- Drop the explicit `await fd.close()` — the stream owns the fd via `autoClose: true` and closes it itself; the previous `fd.close()` raced with the stream's own teardown.
- Add a contract test for `downloadFile` covering multi-chunk writes and fetch errors.

## Why

`writer.end()` only *signals* end-of-stream. Pending chunks may still be flushing to the OS, and the underlying fd is not yet closed. The previous code returned immediately after `writer.end()` and then explicitly called `fd.close()`, racing with the stream's `autoClose` on the same fd.

In Electron usage this surfaced as a real bug: the main process resolves `downloadFile`, the renderer immediately calls `readFile` over IPC, and gets back an empty or partial file even though the download "succeeded". Consumers ended up adding retry/back-off loops to compensate — see [react-app PR #13502](https://github.com/axsy-dev/react-app/pull/13502).

## Test plan

- [x] `npm test` (39 passing, includes 2 new tests for `downloadFile`)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format`
- [ ] Verify in consumer app (`react-app-testbed`) that the app-side retry loop in `runtimePlugins.ts` becomes unnecessary once this is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)